### PR TITLE
feat: add authorization-service

### DIFF
--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -1,0 +1,7 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+.env

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "description": "Store authorization-service",
+  "main": "src/handlers/basicAuthorizer.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "deploy": "sls deploy",
+    "remove": "sls remove"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/authorization-service/serverless.yml
+++ b/authorization-service/serverless.yml
@@ -1,0 +1,29 @@
+service: authorization-service
+frameworkVersion: '3'
+useDotenv: true
+
+provider:
+  name: aws
+  runtime: nodejs18.x
+  stage: dev
+  region: eu-west-1
+  httpApi:
+    cors: true
+    authorizers:
+      tokenAuthorizer:
+        type: request
+        functionName: basicAuthorizer
+  environment:
+    REGION: ${self:provider.region}
+    USERNAME: ${env:USERNAME}
+    PASSWORD: ${env:PASSWORD}
+
+functions:
+  basicAuthorizer:
+    handler: src/handlers/basicAuthorizer.basicAuthorizer
+    events:
+      - httpApi:
+          method: GET
+          path: /token
+          authorizer:
+            name: tokenAuthorizer

--- a/authorization-service/src/handlers/basicAuthorizer.js
+++ b/authorization-service/src/handlers/basicAuthorizer.js
@@ -1,0 +1,23 @@
+import { generateAuthPolicy } from '../utils/generateAuthPolicy.js';
+
+export const basicAuthorizer = async (event, context, callback) => {
+  const authorizationHeader = event.headers.authorization;
+
+  if (!authorizationHeader) return callback('Unauthorized');
+
+  try {
+    const encodedCreds = authorizationHeader.split(' ')[1];
+    const plainCreds = Buffer.from(encodedCreds, 'base64').toString().split(':');
+    const username = plainCreds[0];
+    const password = plainCreds[1];
+
+    const isAuthorized =
+      username === process.env.USERNAME && password === process.env.PASSWORD;
+    const effect = isAuthorized ? 'Allow' : 'Deny';
+    const authResponse = generateAuthPolicy(event, username, effect);
+
+    callback(null, authResponse);
+  } catch (err) {
+    callback(`Unauthorized: ${err.message}`);
+  }
+};

--- a/authorization-service/src/utils/generateAuthPolicy.js
+++ b/authorization-service/src/utils/generateAuthPolicy.js
@@ -1,0 +1,17 @@
+export const generateAuthPolicy = (event, principalId, effect = 'Deny') => {
+  const policy = {
+    principalId,
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect: effect,
+          Resource: event.routeArn,
+        },
+      ],
+    },
+  };
+
+  return policy;
+};

--- a/import-service/serverless.yml
+++ b/import-service/serverless.yml
@@ -9,11 +9,17 @@ provider:
   region: eu-west-1
   httpApi:
     cors: true
+    authorizers:
+      basicAuthorizer:
+        type: request
+        functionArn: arn:aws:lambda:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:function:${self:provider.environment.AUTHORIZER_NAME}
   environment:
     REGION: ${self:provider.region}
     BUCKET_NAME: ${env:BUCKET_NAME}
     QUEUE_NAME: ${env:QUEUE_NAME}
     SQS_URL: ${env:SQS_URL}
+    ACCOUNT_ID: ${env:ACCOUNT_ID}
+    AUTHORIZER_NAME: ${env:AUTHORIZER_NAME}
   iam:
     role:
       statements:
@@ -28,7 +34,7 @@ provider:
             - 'arn:aws:s3:::${self:provider.environment.BUCKET_NAME}/*'
         - Effect: Allow
           Action: 'sqs:*'
-          Resource: 'arn:aws:sqs:eu-west-1:694017690590:${self:provider.environment.QUEUE_NAME}'
+          Resource: 'arn:aws:sqs:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:${self:provider.environment.QUEUE_NAME}'
 
 functions:
   importProductsFile:
@@ -37,6 +43,8 @@ functions:
      - httpApi:
         method: GET
         path: /import
+        authorizer:
+          name: basicAuthorizer
   importFileParser:
     handler: src/handlers/importFileParser.importFileParser
     events:


### PR DESCRIPTION
Tasks:

- created a lambda function `basicAuthorizer` for `authorization-service`
- `basicAuthorizer` lambda has access to the environment variables with credentials: `USERNAME` and `PASSWORD`
- `basicAuthorizer` lambda takes the Basic Authorization token, decodes it, and checks the credentials provided by the token
- `basicAuthorizer` lambda returns 403 HTTP status if access is denied for the user (invalid Authorization token) and 401 HTTP status if Authorization header is not provided
- `basicAuthorizer` lambda is used as the Lambda authorizer to the `/import` path of `import-service`